### PR TITLE
Avoid using dynamic table names in migration

### DIFF
--- a/db/migrations/20170330071824_create_document_table.php
+++ b/db/migrations/20170330071824_create_document_table.php
@@ -2,15 +2,13 @@
 
 use Phinx\Migration\AbstractMigration;
 
-use Pragma\Docs\Models\Document;
-
 class CreateDocumentTable extends AbstractMigration
 {
     public function change()
     {
         if(defined('ORM_ID_AS_UID') && ORM_ID_AS_UID){
           $strategy = defined('ORM_UID_STRATEGY') && ORM_UID_STRATEGY == 'mysql' ? 'mysql' : 'php';
-          $table = $this->table(Document::getTableName(), ['id' => false, 'primary_key' => 'id']);
+          $table = $this->table('documents', ['id' => false, 'primary_key' => 'id']);
           switch($strategy){
             case 'mysql':
               $table->addColumn('id', 'char', ['limit' => 36]);
@@ -22,7 +20,7 @@ class CreateDocumentTable extends AbstractMigration
           }
         }
         else{
-          $table = $this->table(Document::getTableName());
+          $table = $this->table('documents');
         }
         $table->addColumn("name", "string")
               ->addColumn("path", "string")

--- a/db/migrations/20170613154353_create_table_folders.php
+++ b/db/migrations/20170613154353_create_table_folders.php
@@ -2,9 +2,6 @@
 
 use Phinx\Migration\AbstractMigration;
 
-use Pragma\Docs\Models\Document;
-use Pragma\Docs\Models\Folder;
-
 class CreateTableFolders extends AbstractMigration
 {
     /**
@@ -30,10 +27,10 @@ class CreateTableFolders extends AbstractMigration
      */
     public function change()
     {
-        $tableDoc = $this->table(Document::getTableName());
+        $tableDoc = $this->table('documents');
         if(defined('ORM_ID_AS_UID') && ORM_ID_AS_UID){
           $strategy = defined('ORM_UID_STRATEGY') && ORM_UID_STRATEGY == 'mysql' ? 'mysql' : 'php';
-          $table = $this->table(Folder::getTableName(), ['id' => false, 'primary_key' => 'id']);
+          $table = $this->table('folders', ['id' => false, 'primary_key' => 'id']);
           switch($strategy){
             case 'mysql':
               $table->addColumn('id', 'char', ['limit' => 36])
@@ -51,7 +48,7 @@ class CreateTableFolders extends AbstractMigration
           }
         }
         else{
-          $table = $this->table(Folder::getTableName());
+          $table = $this->table('folders');
           $table->addColumn('parent_id', 'integer', ['default' => 0])
             ->addColumn('root_id', 'integer', ['default' => 0]);
           $tableDoc->addColumn('folder_id', 'integer', ['default'=>0, 'after'=>'id']);

--- a/db/migrations/20170823163600_add_uid_to_documents.php
+++ b/db/migrations/20170823163600_add_uid_to_documents.php
@@ -2,14 +2,12 @@
 
 use Phinx\Migration\AbstractMigration;
 
-use Pragma\Docs\Models\Document;
-
 class AddUidToDocuments extends AbstractMigration
 {
 		public function change()
 		{
 			$strategy = defined('ORM_UID_STRATEGY') && ORM_UID_STRATEGY == 'mysql' ? 'mysql' : 'php';
-			$table = $this->table(Document::getTableName());
+			$table = $this->table('documents');
 			$table->addColumn("uid", "string")
 					->update();
 

--- a/phinx.php
+++ b/phinx.php
@@ -17,6 +17,7 @@ return array(
             'pass' => DB_PASSWORD,
             'charset' => 'utf8',
             'collation' => 'utf8_general_ci',
+            'table_prefix' => defined('DB_PREFIX') ? DB_PREFIX : 'pragma_',
         ),
     ),
 );


### PR DESCRIPTION
As class declarations table names might be changed  in further updates,
it would invalidate every previous migrations.